### PR TITLE
sort in numerical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ PayPal: https://www.paypal.me/justinj
 - Only absolute filepaths are supported (for now)
 - ~~File numbers must be zero-padded~~
   - Sorting file with correct order is added in [this PR](https://github.com/neverhood311/Stop-motion-OBJ/pull/15)
-  - Files like file1, file2, file3 will be loaded in correct order, and zero-padded filenames should work, too.
+  - Files like file1, file2, file3 will be loaded in correct order, and zero-padded filenames still work, too.
 - No motion blur
 - ~~Doesn't work with physics~~ 
   - (It actually works with rigid body physics. In Rigid Body Collisions set Shape to 'Mesh' and Source to 'Base')

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ Bitcoin wallet: 16Bbv5jmKJ2T3dqw2rbaiL6vsoZvyNvaU1
 PayPal: https://www.paypal.me/justinj
 
 ### IMPORTANT
-- File numbers must be zero-padded
-  - Like this: file001, file002, file003
-  - NOT like this: ~~file1, file2, file3~~
 - You MUST restart Blender after enabling the add-on
 
 ### Features
@@ -29,7 +26,9 @@ PayPal: https://www.paypal.me/justinj
 
 ### Limitations
 - Only absolute filepaths are supported (for now)
-- File numbers must be zero-padded
+- ~~File numbers must be zero-padded~~
+  - Sorting file with correct order is added in [this PR](https://github.com/neverhood311/Stop-motion-OBJ/pull/15)
+  - Files like file1, file2, file3 will be loaded in correct order, and zero-padded filenames should work, too.
 - No motion blur
 - ~~Doesn't work with physics~~ 
   - (It actually works with rigid body physics. In Rigid Body Collisions set Shape to 'Mesh' and Source to 'Base')

--- a/mesh_sequence_controller.py
+++ b/mesh_sequence_controller.py
@@ -34,27 +34,15 @@ bl_info = {
 
 import bpy
 import os
+import re
 import glob
 from bpy.app.handlers import persistent
 
-import re
-
-def tryint(s):
-    try:
-        return int(s)
-    except:
-        return s
-
-def alphanum_key(s):
+def alphanumKey(string):
     """ Turn a string into a list of string and number chunks.
         "z23a" -> ["z", 23, "a"]
     """
-    return [ tryint(c) for c in re.split('([0-9]+)', s) ]
-
-def sort_nicely(l):
-    """ Sort the given list in the way that humans expect.
-    """
-    l.sort(key=alphanum_key)
+    return [int(c) if c.isdigit() else c for c in re.split('([0-9]+)', string)]
 
 #global variable for the MeshSequenceController
 MSC = None
@@ -184,8 +172,9 @@ class MeshSequenceController:
         print(full_filepath)
         numFrames = 0
         unsortedFiles = glob.glob(full_filepath)
-        sortedFiles = sorted(unsortedFiles)
-        sort_nicely(sortedFiles)
+        # Sort the given list in the way that humans expect.
+        sortedFiles = sorted(unsortedFiles, key=alphanumKey)
+
         #for each file that matches the glob query:
         for file in sortedFiles:
             #import the mesh file

--- a/mesh_sequence_controller.py
+++ b/mesh_sequence_controller.py
@@ -37,6 +37,25 @@ import os
 import glob
 from bpy.app.handlers import persistent
 
+import re
+
+def tryint(s):
+    try:
+        return int(s)
+    except:
+        return s
+
+def alphanum_key(s):
+    """ Turn a string into a list of string and number chunks.
+        "z23a" -> ["z", 23, "a"]
+    """
+    return [ tryint(c) for c in re.split('([0-9]+)', s) ]
+
+def sort_nicely(l):
+    """ Sort the given list in the way that humans expect.
+    """
+    l.sort(key=alphanum_key)
+
 #global variable for the MeshSequenceController
 MSC = None
 
@@ -166,6 +185,7 @@ class MeshSequenceController:
         numFrames = 0
         unsortedFiles = glob.glob(full_filepath)
         sortedFiles = sorted(unsortedFiles)
+        sort_nicely(sortedFiles)
         #for each file that matches the glob query:
         for file in sortedFiles:
             #import the mesh file


### PR DESCRIPTION
Sort the files in numerical order instead of alphabetic order.

Files named like `file{1..100}.obj` can be load in the correct order from 1 to 100, instead of the wrong order 1,10,11 ...

code copied from [this blog](https://nedbatchelder.com/blog/200712/human_sorting.html)