### PR TITLE
Install the addon from a .zip file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 A Blender add-on for importing a sequence of meshes as frames
 
 Stop motion OBJ allows you to import a sequence of OBJ (or STL or PLY) files and render them as individual frames. Have a RealFlow animation but want to render it in Blender? This addon is for you! There are now two versions:
-- [v2.0.1](https://github.com/neverhood311/Stop-motion-OBJ/releases/tag/v2.0.1) for **Blender 2.80+**
+- [v2.0.2](https://github.com/neverhood311/Stop-motion-OBJ/releases/tag/v2.0.2) for **Blender 2.80+**
 - [r1.1.1](https://github.com/neverhood311/Stop-motion-OBJ/releases/tag/0.2.79.2) for Blender 2.79 (also tested for 2.77 and 2.78). This version is now deprecated and will no longer be supported
 
 If you find this add-on helpful, please consider donating to support development:
 
-Bitcoin wallet: 16Bbv5jmKJ2T3dqw2rbaiL6vsoZvyNvaU1
-
 PayPal: https://www.paypal.me/justinj
+
+Bitcoin wallet: 16Bbv5jmKJ2T3dqw2rbaiL6vsoZvyNvaU1
 
 ### IMPORTANT
 - You MUST restart Blender after enabling the add-on
@@ -42,10 +42,11 @@ PayPal: https://www.paypal.me/justinj
   - Sequences can now be duplicated, but they share a material. For a duplicate sequence with a different material, you have to re-import the sequence.
 
 ## Installing Stop motion OBJ
-- Download mesh_sequence_controller.py and move it to Blender's addons folder (something like C:\Program Files\Blender Foundation\Blender\2.80\scripts\addons)
-- Open Blender and open the Add-ons preferences (File > User Preferences... > Add-ons)
+- Find the [latest release](https://github.com/neverhood311/Stop-motion-OBJ/releases) and download the source code .zip file
+- Open Blender and open the Add-ons preferences (Edit > Preferences... > Add-ons)
+- Click Install..., find the .zip file you downloaded, and click Install Add-on
 - In the search bar, type 'OBJ' and look for the Stop motion OBJ addon in the list
-- Check the box to install it, and click 'Save User Settings'
+- Check the box to enable it
 - **RESTART BLENDER BEFORE USING THE ADDON**
 
 ## Using Stop motion OBJ

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,70 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#   Stop motion OBJ: A Mesh sequence importer for Blender
+#   Copyright (C) 2016-2020  Justin Jensen
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from .stop_motion_obj import *
+
+bl_info = {
+    "name" : "Stop motion OBJ",
+    "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
+    "author": "Justin Jensen",
+    "version": (2, 0, 2),
+    "blender": (2, 80, 0),
+    "location": "View 3D > Add > Mesh > Mesh Sequence",
+    "warning": "",
+    "category": "Add Mesh",
+    "wiki_url": "https://github.com/neverhood311/Stop-motion-OBJ",
+    "tracker_url": "https://github.com/neverhood311/Stop-motion-OBJ/issues"
+}
+
+def register():
+    #give bpy.types.Mesh a new property that says whether it's part of a mesh sequence
+    bpy.types.Mesh.inMeshSequence = bpy.props.BoolProperty()    #defaults to False
+    #register this settings class
+    bpy.utils.register_class(MeshSequenceSettings)
+    #add this settings class to bpy.types.Object
+    bpy.types.Object.mesh_sequence_settings = bpy.props.PointerProperty(type=MeshSequenceSettings)
+    bpy.app.handlers.load_post.append(initSequenceController)
+    bpy.app.handlers.frame_change_pre.append(updateFrame)
+    bpy.utils.register_class(AddMeshSequence)
+    bpy.utils.register_class(LoadMeshSequence)
+    bpy.utils.register_class(ReloadMeshSequence)
+    bpy.utils.register_class(BatchShadeSmooth)
+    bpy.utils.register_class(BatchShadeFlat)
+    bpy.utils.register_class(BakeMeshSequence)
+    bpy.utils.register_class(MeshSequencePanel)
+    bpy.types.VIEW3D_MT_mesh_add.append(menu_func)
+    #for running the script, instead of installing the add-on
+    #UNCOMMENT THIS FUNCTION CALL WHEN RUNNING FROM THE TEXT EDITOR
+    #initSequenceController(0)
+
+def unregister():
+    bpy.app.handlers.load_post.remove(initSequenceController)
+    bpy.app.handlers.frame_change_pre.remove(updateFrame)
+    bpy.utils.unregister_class(AddMeshSequence)
+    bpy.utils.unregister_class(LoadMeshSequence)
+    bpy.utils.unregister_class(ReloadMeshSequence)
+    bpy.utils.unregister_class(BatchShadeSmooth)
+    bpy.utils.unregister_class(BatchShadeFlat)
+    bpy.utils.unregister_class(BakeMeshSequence)
+    bpy.utils.unregister_class(MeshSequencePanel)
+    bpy.types.VIEW3D_MT_mesh_add.remove(menu_func)
+
+if __name__ == "__main__":
+    register()

--- a/stop_motion_obj.py
+++ b/stop_motion_obj.py
@@ -1,7 +1,7 @@
 # ##### BEGIN GPL LICENSE BLOCK #####
 #
 #   Stop motion OBJ: A Mesh sequence importer for Blender
-#   Copyright (C) 2016-2019  Justin Jensen
+#   Copyright (C) 2016-2020  Justin Jensen
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -17,20 +17,6 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # ##### END GPL LICENSE BLOCK #####
-
-
-bl_info = {
-    "name" : "Stop motion OBJ",
-    "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
-    "author": "Justin Jensen",
-    "version": (2, 0, 1),
-    "blender": (2, 80, 0),
-    "location": "View 3D > Add > Mesh > Mesh Sequence",
-    "warning": "",
-    "category": "Add Mesh",
-    "wiki_url": "https://github.com/neverhood311/Stop-motion-OBJ",
-    "tracker_url": "https://github.com/neverhood311/Stop-motion-OBJ/issues"
-}
 
 import bpy
 import os
@@ -681,39 +667,3 @@ class MeshSequencePanel(bpy.types.Panel):
                 row = layout.row()
                 box = row.box()
                 box.operator("ms.bake_sequence")
-    
-def register():
-    #give bpy.types.Mesh a new property that says whether it's part of a mesh sequence
-    bpy.types.Mesh.inMeshSequence = bpy.props.BoolProperty()    #defaults to False
-    #register this settings class
-    bpy.utils.register_class(MeshSequenceSettings)
-    #add this settings class to bpy.types.Object
-    bpy.types.Object.mesh_sequence_settings = bpy.props.PointerProperty(type=MeshSequenceSettings)
-    bpy.app.handlers.load_post.append(initSequenceController)
-    bpy.app.handlers.frame_change_pre.append(updateFrame)
-    bpy.utils.register_class(AddMeshSequence)
-    bpy.utils.register_class(LoadMeshSequence)
-    bpy.utils.register_class(ReloadMeshSequence)
-    bpy.utils.register_class(BatchShadeSmooth)
-    bpy.utils.register_class(BatchShadeFlat)
-    bpy.utils.register_class(BakeMeshSequence)
-    bpy.utils.register_class(MeshSequencePanel)
-    bpy.types.VIEW3D_MT_mesh_add.append(menu_func)
-    #for running the script, instead of installing the add-on
-    #UNCOMMENT THIS FUNCTION CALL WHEN RUNNING FROM THE TEXT EDITOR
-    #initSequenceController(0)
-
-def unregister():
-    bpy.app.handlers.load_post.remove(initSequenceController)
-    bpy.app.handlers.frame_change_pre.remove(updateFrame)
-    bpy.utils.unregister_class(AddMeshSequence)
-    bpy.utils.unregister_class(LoadMeshSequence)
-    bpy.utils.unregister_class(ReloadMeshSequence)
-    bpy.utils.unregister_class(BatchShadeSmooth)
-    bpy.utils.unregister_class(BatchShadeFlat)
-    bpy.utils.unregister_class(BakeMeshSequence)
-    bpy.utils.unregister_class(MeshSequencePanel)
-    bpy.types.VIEW3D_MT_mesh_add.remove(menu_func)
-
-if __name__ == "__main__":
-    register()


### PR DESCRIPTION
Because of the project file structure, Blender is unable to properly install the addon from the .zip file downloaded from the Releases page. I've rearranged the file structure to allow that.