### PR TITLE
hide mesh sequence settings for non-sequence objects

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,7 +24,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
     "author": "Justin Jensen",
-    "version": (2, 0, 2, "alpha.4"),
+    "version": (2, 0, 2, "alpha.5"),
     "blender": (2, 80, 0),
     "location": "View 3D > Add > Mesh > Mesh Sequence",
     "warning": "",

--- a/stop_motion_obj.py
+++ b/stop_motion_obj.py
@@ -765,6 +765,10 @@ class MeshSequencePanel(bpy.types.Panel):
     bl_region_type = 'WINDOW'
     bl_context = 'object'
 
+    @classmethod
+    def poll(cls, context):
+        return context.object.mesh_sequence_settings.initialized == True
+
     def draw(self, context):
         layout = self.layout
         obj = context.object


### PR DESCRIPTION
Previously, if you select any object, it would show a Mesh Sequence settings section in the Object properties. For non-sequence objects it would be empty. Now the Mesh Sequence section only shows up for initialized mesh sequences.