### PR TITLE
Clean up cache

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
     "author": "Justin Jensen",
-    "version": (2, 1, 0, "beta.8"),
+    "version": (2, 1, 0, "beta.9"),
     "blender": (2, 80, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/panels.py
+++ b/src/panels.py
@@ -146,7 +146,7 @@ class SequenceImportSettings(bpy.types.PropertyGroup):
     dirPathIsRelative: bpy.props.BoolProperty(
         name="Relative Paths",
         description="Store relative paths for Streaming sequences and for reloading Cached sequences",
-        default=False)
+        default=True)
 
 
 @orientation_helper(axis_forward='-Z', axis_up='Y')

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 1, 0, "beta.8")
+currentScriptVersion = (2, 1, 0, "beta.9")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
Remove extra meshes, materials, and textures when resizing the cache size
Remove duplicate materials and textures when importing a sequence with shared materials
Remove materials and textures from each mesh that is removed from the cache as a result of the cache filling up
Relative paths enabled by default