### PR TITLE
Use separate OBJ import parameters for 2.92 and later

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
     "author": "Justin Jensen",
-    "version": (2, 1, 0),
+    "version": (2, 1, 1),
     "blender": (2, 80, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/panels.py
+++ b/src/panels.py
@@ -229,7 +229,7 @@ class ImportSequence(bpy.types.Operator, ImportHelper):
         dest.obj_use_groups_as_vgroups = source.obj_use_groups_as_vgroups
         dest.obj_use_image_search = source.obj_use_image_search
         dest.obj_split_mode = "OFF"
-        dest.obj_global_clight_size = source.obj_global_clight_size
+        dest.obj_global_clamp_size = source.obj_global_clamp_size
         dest.stl_global_scale = source.stl_global_scale
         dest.stl_use_scene_unit = source.stl_use_scene_unit
         dest.stl_use_facet_normal = source.stl_use_facet_normal
@@ -268,7 +268,7 @@ class SMO_PT_FileImportSettingsPanel(bpy.types.Panel):
             layout.prop(op.importSettings, 'obj_use_image_search')
             layout.prop(op.importSettings, 'obj_use_smooth_groups')
             layout.prop(op.importSettings, 'obj_use_edges')
-            layout.prop(op.importSettings, 'obj_global_clight_size')
+            layout.prop(op.importSettings, 'obj_global_clamp_size')
 
             col = layout.column()
             col.prop(op.importSettings, "obj_use_groups_as_vgroups")

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -1,7 +1,7 @@
 # ##### BEGIN GPL LICENSE BLOCK #####
 #
 #   Stop motion OBJ: A Mesh sequence importer for Blender
-#   Copyright (C) 2016-2020  Justin Jensen
+#   Copyright (C) 2016-2021  Justin Jensen
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -195,7 +195,7 @@ class MeshImporter(bpy.types.PropertyGroup):
     #            ('OFF', "Keep Vert Order", "Keep vertex order from file")))
     obj_use_groups_as_vgroups: bpy.props.BoolProperty(name="Poly Groups", description="Import OBJ groups as vertex groups", default=False)
     obj_use_image_search: bpy.props.BoolProperty(name="Image Search", description="Search subdirs for any associated images (Warning: may be slow)", default=True)
-    obj_global_clight_size: bpy.props.FloatProperty(
+    obj_global_clamp_size: bpy.props.FloatProperty(
         name="Clamp Size",
         description="Clamp bounds under this value (zero to disable)",
         min=0.0,
@@ -239,18 +239,34 @@ class MeshImporter(bpy.types.PropertyGroup):
 
     def loadOBJ(self, filePath):
         # call the obj load function with all the correct parameters
-        bpy.ops.import_scene.obj(
-            filepath=filePath,
-            use_edges=self.obj_use_edges,
-            use_smooth_groups=self.obj_use_smooth_groups,
-            use_split_objects=False,
-            use_split_groups=False,
-            use_groups_as_vgroups=self.obj_use_groups_as_vgroups,
-            use_image_search=self.obj_use_image_search,
-            split_mode="OFF",
-            global_clight_size=self.obj_global_clight_size,
-            axis_forward=self.axis_forward,
-            axis_up=self.axis_up)
+        if bpy.app.version >= (2, 92, 0):
+            bpy.ops.import_scene.obj(
+                filepath=filePath,
+                use_edges=self.obj_use_edges,
+                use_smooth_groups=self.obj_use_smooth_groups,
+                use_split_objects=False,
+                use_split_groups=False,
+                use_groups_as_vgroups=self.obj_use_groups_as_vgroups,
+                use_image_search=self.obj_use_image_search,
+                split_mode="OFF",
+                global_clamp_size=self.obj_global_clamp_size,
+                axis_forward=self.axis_forward,
+                axis_up=self.axis_up)
+        else:
+            # Note the parameter called "global_clight_size", which is probably a typo
+            #   It was corrected to "global_clamp_size" in Blender 2.92
+            bpy.ops.import_scene.obj(
+                filepath=filePath,
+                use_edges=self.obj_use_edges,
+                use_smooth_groups=self.obj_use_smooth_groups,
+                use_split_objects=False,
+                use_split_groups=False,
+                use_groups_as_vgroups=self.obj_use_groups_as_vgroups,
+                use_image_search=self.obj_use_image_search,
+                split_mode="OFF",
+                global_clight_size=self.obj_global_clamp_size,
+                axis_forward=self.axis_forward,
+                axis_up=self.axis_up)
 
     def loadSTL(self, filePath):
         # call the stl load function with all the correct parameters

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 1, 0)
+currentScriptVersion = (2, 1, 1)
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
Detect the Blender version and use different parameters for 2.83, 2.90, 2.91 compared to 2.92