### PR TITLE
Create new empty sequence

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,7 @@
 # ##### BEGIN GPL LICENSE BLOCK #####
 #
 #   Stop motion OBJ: A Mesh sequence importer for Blender
-#   Copyright (C) 2016-2020  Justin Jensen
+#   Copyright (C) 2016-2021  Justin Jensen
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -52,6 +52,8 @@ def register():
     bpy.utils.register_class(BatchShadeFlat)
     bpy.utils.register_class(BakeMeshSequence)
     bpy.utils.register_class(DeepDeleteSequence)
+    bpy.utils.register_class(SeedMeshSequence)
+    bpy.utils.register_class(DuplicateMesh)
     bpy.utils.register_class(SMO_PT_MeshSequencePanel)
     bpy.utils.register_class(SMO_PT_MeshSequencePlaybackPanel)
     bpy.utils.register_class(SMO_PT_MeshSequenceStreamingPanel)
@@ -61,6 +63,7 @@ def register():
     bpy.app.handlers.render_cancel.append(renderCancelHandler)
 
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import_sequence)
+    bpy.types.VIEW3D_MT_object.append(menu_func_seed_sequence)
 
     # the order here is important since it is the order in which these sections will be drawn
     bpy.utils.register_class(SMO_PT_FileImportSettingsPanel)
@@ -85,6 +88,8 @@ def unregister():
     bpy.utils.unregister_class(BatchShadeFlat)
     bpy.utils.unregister_class(BakeMeshSequence)
     bpy.utils.unregister_class(DeepDeleteSequence)
+    bpy.utils.unregister_class(SeedMeshSequence)
+    bpy.utils.unregister_class(DuplicateMesh)
     bpy.utils.unregister_class(SMO_PT_MeshSequencePanel)
     bpy.utils.unregister_class(SMO_PT_MeshSequencePlaybackPanel)
     bpy.utils.unregister_class(SMO_PT_MeshSequenceStreamingPanel)
@@ -93,6 +98,7 @@ def unregister():
     bpy.utils.unregister_class(MeshNameProp)
 
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import_sequence)
+    bpy.types.VIEW3D_MT_object.remove(menu_func_seed_sequence)
     bpy.utils.unregister_class(SMO_PT_FileImportSettingsPanel)
     bpy.utils.unregister_class(SMO_PT_TransformSettingsPanel)
     bpy.utils.unregister_class(SMO_PT_SequenceImportSettingsPanel)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.4"),
+    "version": (2, 2, 0, "alpha.5"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -34,6 +34,7 @@ bl_info = {
     "tracker_url": "https://github.com/neverhood311/Stop-motion-OBJ/issues"
 }
 
+SMOKeymaps = []
 
 def register():
     bpy.types.Mesh.inMeshSequence = bpy.props.BoolProperty()
@@ -52,8 +53,8 @@ def register():
     bpy.utils.register_class(BatchShadeFlat)
     bpy.utils.register_class(BakeMeshSequence)
     bpy.utils.register_class(DeepDeleteSequence)
-    bpy.utils.register_class(SeedMeshSequence)
-    bpy.utils.register_class(DuplicateMesh)
+    bpy.utils.register_class(ConvertToMeshSequence)
+    bpy.utils.register_class(DuplicateMeshFrame)
     bpy.utils.register_class(SMO_PT_MeshSequencePanel)
     bpy.utils.register_class(SMO_PT_MeshSequencePlaybackPanel)
     bpy.utils.register_class(SMO_PT_MeshSequenceStreamingPanel)
@@ -63,7 +64,7 @@ def register():
     bpy.app.handlers.render_cancel.append(renderCancelHandler)
 
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import_sequence)
-    bpy.types.VIEW3D_MT_object.append(menu_func_seed_sequence)
+    bpy.types.VIEW3D_MT_object.append(menu_func_convert_to_sequence)
 
     # the order here is important since it is the order in which these sections will be drawn
     bpy.utils.register_class(SMO_PT_FileImportSettingsPanel)
@@ -75,6 +76,13 @@ def register():
     bpy.app.handlers.load_post.append(makeDirPathsRelative)
     bpy.app.handlers.save_pre.append(makeDirPathsRelative)
 
+    keyConfig = bpy.context.window_manager.keyconfigs.addon
+    if keyConfig:
+        spaceTypes = [('3D View', 'VIEW_3D'), ('Dopesheet', 'DOPESHEET_EDITOR'), ('Graph Editor', 'GRAPH_EDITOR')]
+        for spaceType in spaceTypes:
+            keyMap = keyConfig.keymaps.new(name=spaceType[0], space_type=spaceType[1])
+            keyMapItem = keyMap.keymap_items.new('ms.duplicate_mesh_frame', type='D', value='PRESS', shift=True, ctrl=True)
+            SMOKeymaps.append((keyMap, keyMapItem))
 
 def unregister():
     bpy.app.handlers.load_post.remove(initializeSequences)
@@ -88,8 +96,8 @@ def unregister():
     bpy.utils.unregister_class(BatchShadeFlat)
     bpy.utils.unregister_class(BakeMeshSequence)
     bpy.utils.unregister_class(DeepDeleteSequence)
-    bpy.utils.unregister_class(SeedMeshSequence)
-    bpy.utils.unregister_class(DuplicateMesh)
+    bpy.utils.unregister_class(ConvertToMeshSequence)
+    bpy.utils.unregister_class(DuplicateMeshFrame)
     bpy.utils.unregister_class(SMO_PT_MeshSequencePanel)
     bpy.utils.unregister_class(SMO_PT_MeshSequencePlaybackPanel)
     bpy.utils.unregister_class(SMO_PT_MeshSequenceStreamingPanel)
@@ -98,7 +106,7 @@ def unregister():
     bpy.utils.unregister_class(MeshNameProp)
 
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import_sequence)
-    bpy.types.VIEW3D_MT_object.remove(menu_func_seed_sequence)
+    bpy.types.VIEW3D_MT_object.remove(menu_func_convert_to_sequence)
     bpy.utils.unregister_class(SMO_PT_FileImportSettingsPanel)
     bpy.utils.unregister_class(SMO_PT_TransformSettingsPanel)
     bpy.utils.unregister_class(SMO_PT_SequenceImportSettingsPanel)
@@ -111,6 +119,10 @@ def unregister():
 
     bpy.app.handlers.load_post.remove(makeDirPathsRelative)
     bpy.app.handlers.save_pre.remove(makeDirPathsRelative)
+
+    for km, kmi in SMOKeymaps:
+        km.keymap_items.remove(kmi)
+    SMOKeymaps.clear()
 
 if __name__ == "__main__":
     register()

--- a/src/panels.py
+++ b/src/panels.py
@@ -116,9 +116,11 @@ class SMO_PT_MeshSequenceAdvancedPanel(bpy.types.Panel):
                 row.operator("ms.batch_shade_smooth")
                 row.operator("ms.batch_shade_flat")
 
-                row = layout.row()
-                row.enabled = context.mode == 'OBJECT'
-                row.operator("ms.reload_mesh_sequence")
+                if objSettings.isImported is True:
+                    # non-imported sequences won't have a fileName or dirPath and cannot be reloaded
+                    row = layout.row()
+                    row.enabled = context.mode == 'OBJECT'
+                    row.operator("ms.reload_mesh_sequence")
 
                 row = layout.row()
                 row.enabled = context.mode == 'OBJECT'
@@ -136,7 +138,9 @@ class SMO_PT_MeshSequenceAdvancedPanel(bpy.types.Panel):
             if objSettings.cacheMode == 'streaming':
                 layout.row().label(text="Cached meshes: " + str(objSettings.numMeshesInMemory)  + " meshes")
 
-            layout.row().label(text="Mesh directory: " + objSettings.dirPath)
+            if objSettings.isImported is True:
+                # non-imported sequences won't have a dirPath to display
+                layout.row().label(text="Mesh directory: " + objSettings.dirPath)
             layout.row().label(text="Sequence version: " + objSettings.version.toString())
 
 
@@ -233,6 +237,7 @@ class ImportSequence(bpy.types.Operator, ImportHelper):
         # get the name of the first mesh, remove trailing numbers and _ and .
         firstMeshName = os.path.splitext(mss.meshNameArray[1].basename)[0].rstrip('._0123456789')
         seqObj.name = firstMeshName + '_sequence'
+        seqObj.isImported = True
 
         return {'FINISHED'}
 
@@ -348,3 +353,22 @@ class SMO_PT_SequenceImportSettingsPanel(bpy.types.Panel):
 
 def menu_func_import_sequence(self, context):
     self.layout.operator(ImportSequence.bl_idname, text="Mesh Sequence")
+
+#Add empty mesh sequence operator
+class AddMeshSequence(bpy.types.Operator):
+    """Add Empty Mesh Sequence"""
+    bl_idname = "ms.add_mesh_sequence"
+    #what shows up in the menu
+    bl_label = "Empty Mesh Sequence"
+    bl_options = {'UNDO'}
+
+    def execute(self, context):
+        # TODO: this function is old
+        global MSC
+        obj = MSC.newMeshSequence()
+        
+        return {'FINISHED'}
+
+#the function for adding "Mesh Sequence" to the Add > Mesh menu
+def menu_func_new_sequence(self, context):
+    self.layout.operator(AddMeshSequence.bl_idname, icon="PLUGIN")

--- a/src/panels.py
+++ b/src/panels.py
@@ -108,14 +108,17 @@ class SMO_PT_MeshSequenceAdvancedPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         objSettings = context.object.mesh_sequence_settings
+        inObjectMode = context.mode == 'OBJECT'
+        inSculptMode = context.mode == 'SCULPT'
         if objSettings.loaded is True:
-            if objSettings.isImported is False:
+            # only allow mesh duplication for non-imported sequences in Keyframe playback mode
+            if objSettings.isImported is False and objSettings.frameMode == '4':
                 row = layout.row(align=True)
-                row.enabled = context.mode == 'OBJECT'
-                row.operator("ms.duplicate_current_mesh")
+                row.enabled = inObjectMode or inSculptMode
+                row.operator("ms.duplicate_mesh_frame")
             if objSettings.cacheMode == 'cached':
                 row = layout.row(align=True)
-                row.enabled = context.mode == 'OBJECT'
+                row.enabled = inObjectMode
                 row.label(text="Shading:")
                 row.operator("ms.batch_shade_smooth")
                 row.operator("ms.batch_shade_flat")
@@ -123,15 +126,15 @@ class SMO_PT_MeshSequenceAdvancedPanel(bpy.types.Panel):
                 if objSettings.isImported is True:
                     # non-imported sequences won't have a fileName or dirPath and cannot be reloaded
                     row = layout.row()
-                    row.enabled = context.mode == 'OBJECT'
+                    row.enabled = inObjectMode
                     row.operator("ms.reload_mesh_sequence")
 
                 row = layout.row()
-                row.enabled = context.mode == 'OBJECT'
+                row.enabled = inObjectMode
                 row.operator("ms.bake_sequence")
 
             row = layout.row()
-            row.enabled = context.mode == 'OBJECT'
+            row.enabled = inObjectMode
             row.operator("ms.deep_delete_sequence")
 
             layout.row().separator()
@@ -359,48 +362,96 @@ def menu_func_import_sequence(self, context):
     self.layout.operator(ImportSequence.bl_idname, text="Mesh Sequence")
 
 
-class SeedMeshSequence(bpy.types.Operator):
-    """Seed Mesh Sequence"""
-    bl_idname = "ms.seed_mesh_sequence"
-    bl_label = "Seed Mesh Sequence"
+class ConvertToMeshSequence(bpy.types.Operator):
+    """Convert to Mesh Sequence"""
+    bl_idname = "ms.convert_to_mesh_sequence"
+    bl_label = "Convert to Mesh Sequence"
     bl_options = {'UNDO'}
 
     def execute(self, context):
         obj = context.object
+
+        # if this object is alread a mesh sequence object, return Failure
+        if obj.mesh_sequence_settings.initialized is True:
+            self.report({'ERROR'}, "The selected object is already a mesh sequence")
+            return {'CANCELLED'}
 
         # hijack the mesh from the selected object and add it to a new mesh sequence
         msObj = newMeshSequence()
         msObj.mesh_sequence_settings.isImported = False
         addMeshToSequence(msObj, obj.data)
 
-        # TODO: delete the old object but not its mesh
+        objName = obj.name
+        msObj.name = objName + '_sequence'
+
+        # delete the old object but not its mesh
+        bpy.data.objects.remove(obj)
+
+        # set the mesh sequence playback mode to Keyframe
+        msObj.mesh_sequence_settings.frameMode = '4'
+
+        # create a keyframe for this mesh at the current frame
+        msObj.mesh_sequence_settings.curMeshIdx = 1
+        msObj.keyframe_insert(data_path='mesh_sequence_settings.curMeshIdx', frame=context.scene.frame_current)
+        
+        # make the interpolation constant for the first keyframe
+        meshIdxCurve = next((curve for curve in msObj.animation_data.action.fcurves if 'curMeshIdx' in curve.data_path), None)
+        keyAtFrame = next((keyframe for keyframe in meshIdxCurve.keyframe_points if keyframe.co.x == context.scene.frame_current), None)
+        keyAtFrame.interpolation = 'CONSTANT'
 
         return {'FINISHED'}
 
-def menu_func_seed_sequence(self, context):
-    self.layout.operator(SeedMeshSequence.bl_idname, icon="PLUGIN")
+def menu_func_convert_to_sequence(self, context):
+    if context.object is not None:
+        if context.object.type == 'MESH' and context.object.mesh_sequence_settings.initialized is False:
+            self.layout.separator()
+            self.layout.operator(ConvertToMeshSequence.bl_idname, icon="ONIONSKIN_ON")
 
 
-class DuplicateMesh(bpy.types.Operator):
-    """Duplicate Current Mesh"""
-    bl_idname = "ms.duplicate_current_mesh"
-    bl_label = "Duplicate Current Mesh"
+class DuplicateMeshFrame(bpy.types.Operator):
+    """Make a copy of the current mesh and create a keyframe for it at the current frame"""
+    bl_idname = "ms.duplicate_mesh_frame"
+    bl_label = "Duplicate Mesh Frame"
     bl_options = {'UNDO'}
 
     def execute(self, context):
         obj = context.object
 
-        # TODO:
-        # TODO: if there's already a mesh at this keyframe, just add it to the end? or find the next open keyframe?
+        if obj is None:
+            return {'CANCELLED'}
+
+        # if this object is not a mesh sequence object, return Failure
+        if obj.mesh_sequence_settings.initialized is False:
+            self.report({'ERROR'}, "The selected object is not a mesh sequence")
+            return {'CANCELLED'}
+
+        # if the object doesn't have a 'curMeshIdx' fcurve, we can't add a mesh to it
+        meshIdxCurve = next((curve for curve in obj.animation_data.action.fcurves if 'curMeshIdx' in curve.data_path), None)
+        if meshIdxCurve is None:
+            self.report({'ERROR'}, "The selected mesh sequence has no keyframe curve")
+            return {'CANCELLED'}
+
+        # if the keyframe curve already has a keyframe at this frame number, we can't create another one here
+        keyAtFrame = next((keyframe for keyframe in meshIdxCurve.keyframe_points if keyframe.co.x == context.scene.frame_current), None)
+        if keyAtFrame is not None:
+            self.report({'ERROR'}, "There is already a keyframe at the current frame")
+            return {'CANCELLED'}
+
         # make a copy of the current mesh
         newMesh = obj.data.copy()
+        newMesh.use_fake_user = True
+        newMesh.inMeshSequence = True
 
-        # get its full name
-        newMeshName = newMesh.name_full
+        # add the mesh to the end of the sequence
+        meshIdx = addMeshToSequence(obj, newMesh)
 
-        # add it to the current sequence
-        addMeshToSequence(obj, newMesh)
+        # add a new keyframe at this frame number for the new mesh
+        obj.mesh_sequence_settings.curMeshIdx = meshIdx
+        obj.keyframe_insert(data_path='mesh_sequence_settings.curMeshIdx', frame=context.scene.frame_current)
+        
+        # make the interpolation constant for this keyframe
+        newKeyAtFrame = next((keyframe for keyframe in meshIdxCurve.keyframe_points if keyframe.co.x == context.scene.frame_current), None)
+        newKeyAtFrame.interpolation = 'CONSTANT'
 
-        # TODO: if in keyframe mode, add a new keyframe at this frame number for the new mesh
         return {'FINISHED'}
 

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -1,7 +1,7 @@
 # ##### BEGIN GPL LICENSE BLOCK #####
 #
 #   Stop motion OBJ: A Mesh sequence importer for Blender
-#   Copyright (C) 2016-2020  Justin Jensen
+#   Copyright (C) 2016-2021  Justin Jensen
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -414,6 +414,9 @@ def newMeshSequence():
     emptyMeshNameElement = mss.meshNameArray.add()
     emptyMeshNameElement.key = theMesh.name
     emptyMeshNameElement.inMemory = True
+
+    mss.numMeshes = 1
+    mss.numMeshesInMemory = 1
 
     deselectAll()
     theObj.select_set(state=True)
@@ -1046,4 +1049,30 @@ class DeepDeleteSequence(bpy.types.Operator):
         obj = context.object
         deepDeleteSequence(obj)
         return {'FINISHED'}
+
+
+# 'mesh' is a Blender mesh
+# TODO: write another version that accepts a list of vertices and triangles
+#       and creates a new Blender mesh
+def addMeshToSequence(obj, mesh, idx=-1):
+    mesh.inMeshSequence = True
+
+    mss = obj.mesh_sequence_settings
+
+    # add the new mesh to meshNameArray
+    newMeshNameElement = mss.meshNameArray.add()
+    newMeshNameElement.key = mesh.name_full
+    newMeshNameElement.inMemory = True
+
+    # increment numMeshes
+    mss.numMeshes = mss.numMeshes + 1
+
+    # increment numMeshesInMemory
+    mss.numMeshesInMemory = mss.numMeshesInMemory + 1
+
+    # set initialized to True
+    mss.initialized = True
+
+    # set loaded to True
+    mss.loaded = True
 

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -277,6 +277,10 @@ class MeshNameProp(bpy.types.PropertyGroup):
 
 
 class MeshSequenceSettings(bpy.types.PropertyGroup):
+    isImported: bpy.props.BoolProperty(
+        name="Sequence Is Imported",
+        description="Whether the sequence was loaded from files on disk (True), or created in Blender (False)",
+        default=True)
     version: bpy.props.PointerProperty(type=SequenceVersion)
     fileImporter: bpy.props.PointerProperty(type=MeshImporter)
 

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -1054,10 +1054,10 @@ class DeepDeleteSequence(bpy.types.Operator):
 # 'mesh' is a Blender mesh
 # TODO: write another version that accepts a list of vertices and triangles
 #       and creates a new Blender mesh
-def addMeshToSequence(obj, mesh, idx=-1):
+def addMeshToSequence(seqObj, mesh):
     mesh.inMeshSequence = True
 
-    mss = obj.mesh_sequence_settings
+    mss = seqObj.mesh_sequence_settings
 
     # add the new mesh to meshNameArray
     newMeshNameElement = mss.meshNameArray.add()
@@ -1075,4 +1075,6 @@ def addMeshToSequence(obj, mesh, idx=-1):
 
     # set loaded to True
     mss.loaded = True
+
+    return mss.numMeshes - 1
 

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.4")
+currentScriptVersion = (2, 2, 0, "alpha.5")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
Convert a mesh object to a mesh sequence object by selecting the object, clicking Object > Convert to Mesh Sequence.
Add new mesh frames and keyframes by clicking (in the Object Properties panel) Mesh Sequence > Advanced > Duplicate Mesh Frame or by performing the hotkey Ctrl+Shift+D