### PR TITLE
Sequence shading: remove dependence on bpy.ops

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.9"),
+    "version": (2, 2, 0, "alpha.10"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -820,18 +820,12 @@ def removeMeshFromScene(meshKey, removeOwnedMaterials):
 
 
 def shadeSequence(_obj, smooth):
-    deselectAll()
-    _obj.select_set(state=True)
-    # grab the current mesh so we can put it back later
-    origMesh = _obj.data
     for idx in range(1, _obj.mesh_sequence_settings.numMeshes):
-        _obj.data = getMeshFromIndex(_obj, idx)
-        if(smooth):
-            bpy.ops.object.shade_smooth()
-        else:
-            bpy.ops.object.shade_flat()
-    # reset the sequence's mesh to the right one based on the current frame
-    _obj.data = origMesh
+        mesh = getMeshFromIndex(_obj, idx)
+        mesh.polygons.foreach_set('use_smooth', [smooth] * len(mesh.polygons))
+        
+        # update the mesh to force a UI update
+        mesh.update()
 
 
 def bakeSequence(_obj):

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.9")
+currentScriptVersion = (2, 2, 0, "alpha.10")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
At some point, the Shade Smooth/Flat buttons stopped working. This update fixes them.