### PR TITLE
Add support for X3D sequence import

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY) files and display them each as a single frame of animation. This add-on also supports the .STL and .PLY file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.10"),
+    "version": (2, 2, 0, "alpha.11"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/panels.py
+++ b/src/panels.py
@@ -172,7 +172,8 @@ class SequenceImportSettings(bpy.types.PropertyGroup):
     fileFormat: bpy.props.EnumProperty(
         items=[('obj', 'OBJ', 'Wavefront OBJ'),
                ('stl', 'STL', 'STereoLithography'),
-               ('ply', 'PLY', 'Stanford PLY')],
+               ('ply', 'PLY', 'Stanford PLY'),
+               ('x3d', 'X3D', 'X3D Extensible 3D')],
         name='File Format',
         default='obj')
     dirPathIsRelative: bpy.props.BoolProperty(
@@ -192,7 +193,7 @@ class ImportSequence(bpy.types.Operator, ImportHelper):
     sequenceSettings: bpy.props.PointerProperty(type=SequenceImportSettings)
 
     # for now, we'll just show any file type that Stop Motion OBJ supports
-    filter_glob: bpy.props.StringProperty(default="*.stl;*.obj;*.mtl;*.ply")
+    filter_glob: bpy.props.StringProperty(default="*.stl;*.obj;*.mtl;*.ply;*.x3d")
 
     directory: bpy.props.StringProperty(subtype='DIR_PATH')
 
@@ -327,6 +328,8 @@ class SMO_PT_FileImportSettingsPanel(bpy.types.Panel):
             layout.row().prop(op.importSettings, "stl_use_facet_normal")
         elif op.sequenceSettings.fileFormat == 'ply':
             layout.label(text="No .ply settings")
+        elif op.sequenceSettings.fileFormat == 'x3d':
+            layout.label(text="No .x3d settings")
 
 
 class SMO_PT_TransformSettingsPanel(bpy.types.Panel):

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -169,6 +169,8 @@ def fileExtensionFromType(_type):
         return 'stl'
     elif(_type == 'ply'):
         return 'ply'
+    elif(_type == 'x3d'):
+        return 'x3d'
     return ''
 
 
@@ -229,6 +231,7 @@ class MeshImporter(bpy.types.PropertyGroup):
         default=False)
 
     # (PLY has no import parameters)
+    # (X3D has no import parameters)
     # Shared import parameters
     axis_forward: bpy.props.StringProperty(name="Axis Forward",default="-Z")
     axis_up: bpy.props.StringProperty(name="Axis Up",default="Y")
@@ -243,6 +246,8 @@ class MeshImporter(bpy.types.PropertyGroup):
             self.loadSTL(filePath)
         elif fileType == 'ply':
             self.loadPLY(filePath)
+        elif fileType == 'x3d':
+            self.loadX3D(filePath)
 
     def loadOBJ(self, filePath):
         # call the obj load function with all the correct parameters
@@ -289,6 +294,12 @@ class MeshImporter(bpy.types.PropertyGroup):
         # call the ply load function with all the correct parameters
         bpy.ops.import_mesh.ply(filepath=filePath)
 
+    def loadX3D(self, filePath):
+        bpy.ops.import_scene.x3d(
+            filepath=filePath,
+            axis_forward=self.axis_forward,
+            axis_up=self.axis_up)
+
 
 class MeshNameProp(bpy.types.PropertyGroup):
     key: bpy.props.StringProperty()
@@ -334,7 +345,8 @@ class MeshSequenceSettings(bpy.types.PropertyGroup):
     fileFormat: bpy.props.EnumProperty(
         items=[('obj', 'OBJ', 'Wavefront OBJ'),
                ('stl', 'STL', 'STereoLithography'),
-               ('ply', 'PLY', 'Stanford PLY')],
+               ('ply', 'PLY', 'Stanford PLY'),
+               ('x3d', 'X3D', 'X3D Extensible 3D')],
         name='File Format',
         default='obj')
 

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.10")
+currentScriptVersion = (2, 2, 0, "alpha.11")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
Limitations:
 - This only handles single-object .x3d files. If a .x3d file contains multiple objects, only the first one is imported. 
 - Object transformations are not imported. Transformations must be applied to the actual vertices before importing