### PR TITLE
Don't create a sequence object if it can't find any files

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY or X3D) files and display them each as a single frame of animation. This add-on also supports the .STL, .PLY, and .X3D file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.14"),
+    "version": (2, 2, 0, "alpha.15"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.14")
+currentScriptVersion = (2, 2, 0, "alpha.15")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
Also, report the offending file name prefixes to the user.