### PR TITLE
Added better support for alembic export

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY or X3D) files and display them each as a single frame of animation. This add-on also supports the .STL, .PLY, and .X3D file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.16"),
+    "version": (2, 2, 0, "alpha.17"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -47,6 +47,9 @@ def register():
     bpy.app.handlers.frame_change_pre.append(updateFrame)
     
     # note: Blender tends to crash in Rendered viewport mode if we set the depsgraph_update_post instead of depsgraph_update_pre
+
+    # Alembic exporter crashes blender when the depsgraph_update_pre function is registered. depsgraph_update_post doesn't crash it
+    # Is it needed?
     bpy.app.handlers.depsgraph_update_pre.append(updateFrame)
     bpy.utils.register_class(ReloadMeshSequence)
     bpy.utils.register_class(BatchShadeSmooth)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -45,12 +45,15 @@ def register():
     bpy.types.Object.mesh_sequence_settings = bpy.props.PointerProperty(type=MeshSequenceSettings)
     bpy.app.handlers.load_post.append(initializeSequences)
     bpy.app.handlers.frame_change_pre.append(updateFrame)
+    bpy.app.handlers.frame_change_pre.append(updateFrameSingleMesh)
     
     # note: Blender tends to crash in Rendered viewport mode if we set the depsgraph_update_post instead of depsgraph_update_pre
 
     # Alembic exporter crashes blender when the depsgraph_update_pre function is registered. depsgraph_update_post doesn't crash it
     # Is it needed?
     bpy.app.handlers.depsgraph_update_pre.append(updateFrame)
+    #Workaround, updating Single mesh in Depsgraph_Update_Pre crashes Blender during alembic support
+    bpy.app.handlers.depsgraph_update_post.append(updateFrameSingleMesh) 
     bpy.utils.register_class(ReloadMeshSequence)
     bpy.utils.register_class(BatchShadeSmooth)
     bpy.utils.register_class(BatchShadeFlat)
@@ -91,7 +94,9 @@ def register():
 def unregister():
     bpy.app.handlers.load_post.remove(initializeSequences)
     bpy.app.handlers.frame_change_pre.remove(updateFrame)
+    bpy.app.handlers.frame_change_pre.remove(updateFrameSingleMesh)
     bpy.app.handlers.depsgraph_update_pre.remove(updateFrame)
+    bpy.app.handlers.depsgraph_update_post.remove(updateFrameSingleMesh)
     bpy.app.handlers.render_init.remove(renderInitHandler)
     bpy.app.handlers.render_complete.remove(renderCompleteHandler)
     bpy.app.handlers.render_cancel.remove(renderCancelHandler)

--- a/src/panels.py
+++ b/src/panels.py
@@ -181,7 +181,7 @@ class SequenceImportSettings(bpy.types.PropertyGroup):
         description="Store relative paths for Streaming sequences and for reloading Cached sequences",
         default=True)
     showAsSingleMesh: bpy.props.BoolProperty(
-        name='Show as single Mesh',
+        name='Show as Single Mesh',
         description='All frames will be shown in the same mesh. Useful when exporting the frames as alembic.',
         default=False)
 
@@ -286,7 +286,7 @@ class ImportSequence(bpy.types.Operator, ImportHelper):
                 # If we import the sequence as a single mesh, the user most likey
                 # wants to export it as an alembic. Without a modifier attached,
                 # blender won't export the alembic correctly, so we add a harmless one
-                if(mss.showAsSingleMesh):
+                if mss.showAsSingleMesh:
                     arrayModifier = seqObj.modifiers.new(name='Array', type='ARRAY')
                     arrayModifier.count = 1
 

--- a/src/panels.py
+++ b/src/panels.py
@@ -180,6 +180,10 @@ class SequenceImportSettings(bpy.types.PropertyGroup):
         name="Relative Paths",
         description="Store relative paths for Streaming sequences and for reloading Cached sequences",
         default=True)
+    showAsSingleMesh: bpy.props.BoolProperty(
+        name='Show as single Mesh',
+        description='All frames will be shown in the same mesh. Useful when exporting the frames as alembic.',
+        default=False)
 
 
 @orientation_helper(axis_forward='-Z', axis_up='Y')
@@ -230,7 +234,11 @@ class ImportSequence(bpy.types.Operator, ImportHelper):
             if countMatchingFiles(dirPath, basenamePrefix, fileExtensionFromType(self.sequenceSettings.fileFormat)) > 0:
                 # the input parameters should be stored on 'self'
                 # create a new mesh sequence
-                seqObj = newMeshSequence()
+                if self.sequenceSettings.showAsSingleMesh:
+                    seqObj = newMeshSequence('SingleMesh')
+                else:
+                    seqObj = newMeshSequence('EmptyMesh')
+
                 global_matrix = axis_conversion(from_forward=b_axis_forward,from_up=b_axis_up).to_4x4()
                 seqObj.matrix_world = global_matrix
 
@@ -243,6 +251,8 @@ class ImportSequence(bpy.types.Operator, ImportHelper):
                 mss.cacheMode = self.sequenceSettings.cacheMode
                 mss.fileFormat = self.sequenceSettings.fileFormat
                 mss.dirPathIsRelative = self.sequenceSettings.dirPathIsRelative
+                mss.showAsSingleMesh = self.sequenceSettings.showAsSingleMesh
+
 
                 # this needs to be set to True if dirPath is supposed to be relative
                 # once the path is made relative, it will be set to False
@@ -272,6 +282,14 @@ class ImportSequence(bpy.types.Operator, ImportHelper):
                 firstMeshName = os.path.splitext(mss.meshNameArray[1].basename)[0].rstrip('._0123456789')
                 seqObj.name = createUniqueName(firstMeshName + '_sequence', bpy.data.objects)
                 seqObj.mesh_sequence_settings.isImported = True
+
+                # If we import the sequence as a single mesh, the user most likey
+                # wants to export it as an alembic. Without a modifier attached,
+                # blender won't export the alembic correctly, so we add a harmless one
+                if(mss.showAsSingleMesh):
+                    arrayModifier = seqObj.modifiers.new(name='Array', type='ARRAY')
+                    arrayModifier.count = 1
+
             else:
                 # this filename prefix had no matching files
                 noMatchFileNames.append(fileName)
@@ -391,6 +409,8 @@ class SMO_PT_SequenceImportSettingsPanel(bpy.types.Panel):
         col.prop(op.sequenceSettings, "cacheMode")
         col.prop(op.sequenceSettings, "perFrameMaterial")
         col.prop(op.sequenceSettings, "dirPathIsRelative")
+        col.prop(op.sequenceSettings, "showAsSingleMesh")
+
 
 
 def menu_func_import_sequence(self, context):

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -347,7 +347,7 @@ class MeshSequenceSettings(bpy.types.PropertyGroup):
     # With this option enabled, all frames will always be shown in the same mesh container.
     # Also adds an array modifier, as the alembic export won't correctly work otherwise
     showAsSingleMesh: bpy.props.BoolProperty(
-        name='Show as Single Mesh',
+        name='Enable Alembic Export',
         description='All frames will be shown in the same mesh. Recommended when exporting the frames as Alembic',
         default=False)
 

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -81,8 +81,8 @@ def updateFrame(scene):
         scn = bpy.context.scene
         setFrameNumber(scn.frame_current, False)
 
-#Workaround for a bug where Blender crashes when Depsgraph_Update_Pre calls updateFrame and a Single Mesh is used.
-#Don't call this function in Depsgraph_Update_Pre. See PR #154 for more infos
+# Workaround for a bug where Blender crashes when Depsgraph_Update_Pre calls updateFrame and a Single Mesh is used.
+# Don't call this function in Depsgraph_Update_Pre. See PR #154 for more infos
 @persistent
 def updateFrameSingleMesh(scene):
     global loadingSequenceLock
@@ -344,10 +344,10 @@ class MeshSequenceSettings(bpy.types.PropertyGroup):
         name='Material per Frame',
         default=False)
 
-    #With this option enabled, all frames will always be shown in the same mesh container.
-    #Also adds an array modifier, as the alembic export won't correctly work otherwise
+    # With this option enabled, all frames will always be shown in the same mesh container.
+    # Also adds an array modifier, as the alembic export won't correctly work otherwise
     showAsSingleMesh: bpy.props.BoolProperty(
-        name='Show as single Mesh',
+        name='Show as Single Mesh',
         description='All frames will be shown in the same mesh. Recommended when exporting the frames as Alembic',
         default=False)
 
@@ -750,8 +750,8 @@ def setFrameObj(_obj, frameNum, updateSingleMesh):
     
     mss = _obj.mesh_sequence_settings
 
-    #Update single mesh frames only when we explicitly want to
-    if(not(updateSingleMesh is False and mss.showAsSingleMesh is True)):
+    # Update single mesh frames only when we explicitly want to
+    if not (updateSingleMesh is False and mss.showAsSingleMesh is True):
         # store the current materials for grabbing them later
         prev_mesh_materials = []
         for material in _obj.data.materials:
@@ -768,7 +768,7 @@ def setFrameObjStreamed(obj, frameNum, updateSingleMesh, forceLoad=False, delete
     
     mss = obj.mesh_sequence_settings
 
-    if(not(updateSingleMesh is False and mss.showAsSingleMesh is True)):        
+    if not (updateSingleMesh is False and mss.showAsSingleMesh is True):        
         idx = getMeshIdxFromFrameNumber(obj, frameNum)
         nextMeshProp = getMeshPropFromIndex(obj, idx)
 
@@ -796,33 +796,31 @@ def setFrameObjStreamed(obj, frameNum, updateSingleMesh, forceLoad=False, delete
             if idxToDelete >= 0:
                 removeMeshFromCache(obj, idxToDelete)
 
-def swapMeshAndMaterials(old_Object, new_Mesh, old_mesh_materials, forSingleMesh):
-
-    if (new_Mesh != old_Object.data):                
-        
-        #For normal sequences we simply swap the mesh container
+def swapMeshAndMaterials(oldObject, newMesh, oldMeshMaterials, forSingleMesh):
+    if (newMesh != oldObject.data):                        
+        # For normal sequences we simply swap the mesh container
         if(forSingleMesh is False):
-            old_Object.data = new_Mesh
+            oldObject.data = newMesh
         
-        #For single mesh sequences, we need to copy the mesh data via a bmesh, so that the container stays the same
+        # For single mesh sequences, we need to copy the mesh data via a bmesh, so that the container stays the same
         else:
             bmNew = bmesh.new()
-            bmNew.from_mesh(new_Mesh)     
-            bmNew.to_mesh(old_Object.data)
+            bmNew.from_mesh(newMesh)     
+            bmNew.to_mesh(oldObject.data)
             bmNew.free()
             
-            #Also copy the materials from the previous mesh container
-            if(len(new_Mesh.materials) > 0):
-                old_Object.data.materials.clear()
-                for material in new_Mesh.materials:
-                    old_Object.data.materials.append(material)
+            # Also copy the materials from the previous mesh container
+            if(len(newMesh.materials) > 0):
+                oldObject.data.materials.clear()
+                for material in newMesh.materials:
+                    oldObject.data.materials.append(material)
         
-        if old_Object.mesh_sequence_settings.perFrameMaterial is False:
-            # if the previous mesh had a material, copy it to the new one
-            if(len(old_mesh_materials) > 0):
-                old_Object.data.materials.clear()
-                for material in old_mesh_materials:
-                    old_Object.data.materials.append(material)
+        if oldObject.mesh_sequence_settings.perFrameMaterial is False:
+            # If the previous mesh had a material, copy it to the new one
+            if(len(oldMeshMaterials) > 0):
+                oldObject.data.materials.clear()
+                for material in oldMeshMaterials:
+                    oldObject.data.materials.append(material)
 
 def nextCachedMeshToDelete(obj, currentMeshIdx):
     mss = obj.mesh_sequence_settings

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.16")
+currentScriptVersion = (2, 2, 0, "alpha.17")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
Dear neverhood,

Thank you for your work on this plugin! I use it mainly to export .obj sequences to alembic files and as you said yourself on the wiki, export for alembic files isn't too reliable in the current state. As I need to convert lots of sequences to alembic for my work project, I tried to improve this process a bit and maybe you're interested in integrating these changes into the plugin.

**Problems encountered:**
I figured out that the main problem when exporting sequences to alembic is the way the exporter expects the structure of the scene hierachy. In the current state, the exporter detects each frame as a single unique mesh. They are exported as individual "tracks" (objects) in alembic terms. So for a sequence of 900 frames, 900 tracks with a single frame each are created in the alembic file.
This creates two problems: 

1: On reimport of the alembic file, all the tracks will start at the same time, so you get something that looks like this (Animation with 5 frames):

![grafik](https://user-images.githubusercontent.com/39704202/149956005-01b00b12-d88d-4095-95c6-910d226b36cb.png)

2: Some importers, like the Unreal Engine importer can't really handle this many tracks and they crash.

**Improvements**
To fix the problems with the scene hierachy, I added an option in the importer menu, to display all of the frames on the same mesh. Before, the mesh object data was always swapped, this led to the alembic exporter interpreting each frame as new mesh/track.
With the option enabled, the mesh object stays the same, but all it's vertices/polygons/uvs ect. are changed. This causes the exporter to recognize that all the frames are belonging to the same track/mesh.

![grafik](https://user-images.githubusercontent.com/39704202/149958206-c7ec3485-e076-49e1-84cd-5fd7d440d3d2.png)

There is a small workaround however that is needed. Blender needs to see a modifier on the object to recognize it has an animation, so I added an array modifier with the count set to 0 to make it work properly. This should be relativly harmless.

With the changes, I can also successfully import alembic files into Unreal Engine!

**Testing**

I tested the new changes with caching, streaming, one material per frame on/off, saving/opening as .blend file, deleting and baking.

**Known problems**

The changes work perfectly with version 2.11, but on version 2.2 the added line 50 in the init file:      `bpy.app.handlers.depsgraph_update_pre.append(updateFrame)`
causes a crash when exporting to alembic. I don't really understand what this does well enough to have a solution for that problem right now, so I think I need your input here.

I'm also not too sure if the name "Show as single mesh" really describes what these changes do well enough. There probably is a better name.




If you got any questions, let me know! I think there are a lot of people who want to use this plugin for exporting to alembic, so I hope it's a welcome addition :)

