### PR TITLE
Fix ConvertToMeshSequence operator

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY or X3D) files and display them each as a single frame of animation. This add-on also supports the .STL, .PLY, and .X3D file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.21"),
+    "version": (2, 2, 0, "alpha.22"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/panels.py
+++ b/src/panels.py
@@ -450,7 +450,7 @@ class ConvertToMeshSequence(bpy.types.Operator):
             return {'CANCELLED'}
 
         # hijack the mesh from the selected object and add it to a new mesh sequence
-        msObj = newMeshSequence('emptyMesh')
+        msObj = newMeshSequence()
         msObj.mesh_sequence_settings.isImported = False
         addMeshToSequence(msObj, obj.data)
 

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.21")
+currentScriptVersion = (2, 2, 0, "alpha.22")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
There is an error in the `ConvertToMeshSequence` operator.
When converting an object into a mesh sequence, the following exception is thrown:

```
/home/hnum/.config/blender/3.0/scripts/addons/Stop-motion-OBJ/panels.py:44
Info: See 'panels.py' in the text editor

Python: Traceback (most recent call last):
  File "/home/hnum/.config/blender/3.0/scripts/addons/Stop-motion-OBJ/panels.py", line 453, in execute
    msObj = newMeshSequence('emptyMesh')
TypeError: newMeshSequence() takes 0 positional arguments but 1 was given

location: <unknown location>:-1
Error: Python: Traceback (most recent call last):
  File "/home/hnum/.config/blender/3.0/scripts/addons/Stop-motion-OBJ/panels.py", line 453, in execute
    msObj = newMeshSequence('emptyMesh')
TypeError: newMeshSequence() takes 0 positional arguments but 1 was given

location: <unknown location>:-1
```

I think it comes from PR #155.

It seems to be working as intended now.
