### PR TITLE
Fix issue checkMeshChangesFrameChangePre

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY or X3D) files and display them each as a single frame of animation. This add-on also supports the .STL, .PLY, and .X3D file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.22"),
+    "version": (2, 2, 0, "alpha.23"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "name": "Stop motion OBJ",
     "description": "Import a sequence of OBJ (or STL or PLY or X3D) files and display them each as a single frame of animation. This add-on also supports the .STL, .PLY, and .X3D file formats.",
     "author": "Justin Jensen",
-    "version": (2, 2, 0, "alpha.21"),
+    "version": (2, 2, 0, "alpha.22"),
     "blender": (2, 83, 0),
     "location": "File > Import > Mesh Sequence",
     "warning": "",

--- a/src/stop_motion_obj.py
+++ b/src/stop_motion_obj.py
@@ -56,8 +56,11 @@ def checkMeshChangesFrameChangePre(scene):
     global inRenderMode
     if inRenderMode == True:
         return
-
+    
     obj = bpy.context.object
+    # make sure an object is selected
+    if obj is None:
+        return
 
     # if the selected object is not a loaded and initialized mesh sequence, return
     mss = obj.mesh_sequence_settings

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.22")
+currentScriptVersion = (2, 2, 0, "alpha.23")
 legacyScriptVersion = (2, 0, 2, "legacy")

--- a/src/version.py
+++ b/src/version.py
@@ -2,5 +2,5 @@
 # (major, minor, revision, development)
 # example dev version: (1, 2, 3, "beta.4")
 # example release version: (2, 3, 4)
-currentScriptVersion = (2, 2, 0, "alpha.21")
+currentScriptVersion = (2, 2, 0, "alpha.22")
 legacyScriptVersion = (2, 0, 2, "legacy")


### PR DESCRIPTION
I have this error message sometimes using the addon:

```python
Traceback (most recent call last):
  File "/home/hnum/.config/blender/3.0/scripts/addons/Stop-motion-OBJ/stop_motion_obj.py", line 70, in checkMeshChangesFrameChangePre
    mss = obj.mesh_sequence_settings
AttributeError: 'NoneType' object has no attribute 'mesh_sequence_settings'
```

This PR should solve this issue.